### PR TITLE
use global symbol to customize string representations in Node.js REPL

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
     },
     {
       "files": ["index.js"],
-      "globals": {"Deno": false},
+      "globals": {"Deno": false, "process": false},
       "rules": {
         "multiline-comment-style": ["off"]
       }

--- a/index.js
+++ b/index.js
@@ -24,23 +24,18 @@
 
   'use strict';
 
-  const util = {inspect: {}};
-
   /* istanbul ignore else */
   if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = f (require ('util'),
-                        require ('sanctuary-show'),
+    module.exports = f (require ('sanctuary-show'),
                         require ('sanctuary-type-classes'));
   } else if (typeof define === 'function' && define.amd != null) {
-    define (['sanctuary-show', 'sanctuary-type-classes'],
-            (show, Z) => f (util, show, Z));
+    define (['sanctuary-show', 'sanctuary-type-classes'], f);
   } else {
-    self.sanctuaryIdentity = f (util,
-                                self.sanctuaryShow,
+    self.sanctuaryIdentity = f (self.sanctuaryShow,
                                 self.sanctuaryTypeClasses);
   }
 
-}) ((util, show, Z) => {
+}) ((show, Z) => {
 
   'use strict';
 
@@ -69,17 +64,21 @@
     /* eslint-enable key-spacing */
   };
 
-  {
-    const {custom} = util.inspect;  // added in Node.js v6.6.0
-    /* istanbul ignore else */
-    if (typeof custom === 'symbol') {
-      prototype[custom] = Identity$prototype$show;
-    }
-    /* istanbul ignore if */
-    if (typeof Deno !== 'undefined') {
-      if (Deno != null && typeof Deno.customInspect === 'symbol') {
-        prototype[Deno.customInspect] = Identity$prototype$show;
-      }
+  /* istanbul ignore else */
+  if (
+    typeof process !== 'undefined' &&
+    process != null &&
+    process.versions != null &&
+    process.versions.node != null
+  ) {
+    prototype[
+      Symbol.for ('nodejs.util.inspect.custom')  // added in Node.js v10.12.0
+    ] = Identity$prototype$show;
+  }
+  /* istanbul ignore if */
+  if (typeof Deno !== 'undefined') {
+    if (Deno != null && typeof Deno.customInspect === 'symbol') {
+      prototype[Deno.customInspect] = Identity$prototype$show;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "/package.json"
   ],
   "engines": {
-    "node": ">=6.6.0"
+    "node": ">=10.12.0"
   },
   "dependencies": {
     "sanctuary-show": "2.0.0",


### PR DESCRIPTION
Relates to sanctuary-js/sanctuary#718

<https://nodejs.org/en/blog/release/v10.12.0/>

/cc @majkelch
